### PR TITLE
fix departement list

### DIFF
--- a/src/_programs.qmd
+++ b/src/_programs.qmd
@@ -65,7 +65,7 @@ function print_program_departement_single(langage, value, selectedlevel, format,
             from cartiflette import carti_download
             shp_communes = carti_download(
                 crs = 4326,
-                values = "${value}",
+                values = ["${value.join('", "')}"],
                 borders="${selectedlevel}",
                 vectorfile_format="${format}",
                 filter_by="DEPARTEMENT",
@@ -76,7 +76,7 @@ function print_program_departement_single(langage, value, selectedlevel, format,
             return md`
             import {carti_download} from "@linogaliana/cartiflette-js"
             carti_download({
-                value: "${value}",
+                values = ["${value.join('", "')}"],
                 borders: "${selectedlevel}",
                 vectorfileFormat: "${format}",
                 year: ${year},
@@ -90,7 +90,7 @@ function print_program_departement_single(langage, value, selectedlevel, format,
             library(cartiflette)
             shp_communes <- carti_download(
                 crs = 4326,
-                values = c("${value}"),
+                values = c("${value.join('", "')}"),
                 borders = "${selectedlevel}",
                 vectorfile_format = "${format}",
                 filter_by = "DEPARTEMENT",


### PR DESCRIPTION
Lino,
La liste des départements dans le bloc de code exemple dans la partie Départements, s'affiche sous forme de string au lieu de liste.
Là j'ai corrigé. Par contre je ne connais pas R, alors là dans la correction ça donne : 
values = c("75", "92", "93", "94"),

Est-ce qu'il faut plutôt mettre : 
values = c(["75", "92", "93", "94"]), ?